### PR TITLE
add scaffold dva-hackernews to antd scaffold

### DIFF
--- a/scaffolds/dva-hackernews/index.yml
+++ b/scaffolds/dva-hackernews/index.yml
@@ -1,0 +1,9 @@
+url: 'https://github.com/dvajs/dva-hackernews'
+name: dva-hackernews
+git_url: 'git://github.com/dvajs/dva-hackernews.git'
+chineseName: dva-hackernews
+author: dvajs
+description: HackerNews clone built with Dva.
+version: 0.0.1
+industry: react
+source: npm


### PR DESCRIPTION
url: 'https://github.com/dvajs/dva-hackernews'
name: dva-hackernews
git_url: 'git://github.com/dvajs/dva-hackernews.git'
chineseName: dva-hackernews
author: dvajs
description: HackerNews clone built with Dva.
version: 0.0.1
industry: react
source: npm
