### PR TITLE
add scaffold dva-hackernews to antd scaffold

### DIFF
--- a/scaffolds/dva-hackernews/index.yml
+++ b/scaffolds/dva-hackernews/index.yml
@@ -1,9 +1,80 @@
-url: 'https://github.com/dvajs/dva-hackernews'
 name: dva-hackernews
 git_url: 'git://github.com/dvajs/dva-hackernews.git'
-chineseName: dva-hackernews
 author: dvajs
 description: HackerNews clone built with Dva.
-version: 0.0.1
-industry: react
-source: npm
+version: ''
+tags:
+  - dva
+  - react
+  - hacknews
+coverPicture: 'https://ucarecdn.com/399ead84-8022-42c1-b8fd-c32526b39cdc/'
+readme: >
+  # dva-hackernews
+
+
+  HackerNews clone built with [Dva](https://github.com/dvajs/dva), based on
+  [vue-hackernews-2.0](https://github.com/vuejs/vue-hackernews-2.0).
+
+
+  <p align="center">
+    <a href="http://dvajs.github.io/dva-hackernews/">
+      <img src="https://zos.alipayobjects.com/rmsportal/XUTutezexphTbgs.png" width="700" />
+      <br />
+      Live Demo
+    </a>
+  </p>
+
+
+  ## TODO
+
+
+  - [x] Item Page
+
+  - [x] Comment Page
+
+  - [x] User Page
+
+  - [x] Real-time List Update with Animation
+
+  - [x] Router Transform Animation
+
+  - [ ] SSR
+
+  - [ ] Dynamic Router
+
+  - [ ] Handle loading status automatically
+
+  - [ ] Render Performance
+
+
+  ## Run Locally
+
+
+  Install dependencies.
+
+
+  ```bash
+
+  $ npm install
+
+  ```
+
+
+  Start server.
+
+
+  ```bash
+
+  $ npm start
+
+  ```
+
+
+  Open app in browser.
+
+
+  ```bash
+
+  $ open http://localhost:8989/
+
+  ```


### PR DESCRIPTION
name: dva-hackernews
git_url: 'git://github.com/dvajs/dva-hackernews.git'
author: dvajs
description: HackerNews clone built with Dva.
version: ''
tags:
  - dva
  - react
  - hacknews
coverPicture: 'https://ucarecdn.com/399ead84-8022-42c1-b8fd-c32526b39cdc/'
