### PR TITLE
Add react-redux-antd-starter to the market

### DIFF
--- a/scaffolds/react-redux-antd-starter/index.yml
+++ b/scaffolds/react-redux-antd-starter/index.yml
@@ -1,0 +1,59 @@
+name: react-redux-antd-starter
+git_url: 'git://github.com/BetaRabbit/react-redux-antd-starter.git'
+author: BetaRabbit
+description: A React + Redux + Ant-Design frontend boilerplate
+tags:
+  - antd
+  - redux
+  - react
+coverPicture: null
+readme: |
+  # react-redux-antd-starter
+  A React + Redux + Ant-Design frontend boilerplate.
+
+  - [x] React
+  - [x] Redux
+  - [x] Ant-Design
+  - [x] React Router
+  - [x] React Router Redux
+  - [x] Redux Actions
+  - [x] Babel
+  - [x] PostCSS
+  - [x] LESS
+  - [ ] CSS Modules
+  - [x] ESLint (Airbnb)
+  - [x] JWT
+  - [ ] Examples
+
+  ## npm scripts
+
+  ### Dev
+  ```
+  npm run dev
+  ```
+  Open `http://localhost:3000` in your browser.
+
+  ### Lint
+
+  #### Lint only
+  ```
+  npm run lint
+  ```
+
+  #### Auto fix
+  ```
+  npm run lint:fix
+  ```
+
+  #### Build
+  ```
+  npm run build
+  ```
+  Find built files in ./dist.
+
+  #### Start (production)
+  ```
+  npm run start
+  ```
+  Open `http://localhost:3000` in your browser.
+deployedAt: 2017-05-24T12:13:35.771Z


### PR DESCRIPTION

- Name: `react-redux-antd-starter`
- Url: `git://github.com/BetaRabbit/react-redux-antd-starter.git`

        