### PR TITLE
Add react-redux-router-antd-int-cli to the market

### DIFF
--- a/scaffolds/react-redux-router-antd-int-cli/index.yml
+++ b/scaffolds/react-redux-router-antd-int-cli/index.yml
@@ -1,0 +1,8 @@
+name: react-redux-router-antd-int-cli
+git_url: 'git://github.com/KK-Lin/react-redux-router-antd-int-cli.git'
+author: KK-Lin
+description: react-redux-router-antd-int-cli
+tags: []
+coverPicture: null
+readme: ''
+deployedAt: 2017-06-15T15:48:13.927Z


### PR DESCRIPTION

- Name: `react-redux-router-antd-int-cli`
- Url: `git://github.com/KK-Lin/react-redux-router-antd-int-cli.git`

        