### PR TITLE
Add angular-material-dashboard to the market

### DIFF
--- a/scaffolds/angular-material-dashboard/index.yml
+++ b/scaffolds/angular-material-dashboard/index.yml
@@ -1,0 +1,116 @@
+name: angular-material-dashboard
+git_url: 'git://github.com/wangdicoder/angular-material-dashboard.git'
+author: wangdicoder
+description: a material-design dashboard by using angular
+tags:
+  - angular
+  - material design
+  - dashboard
+coverPicture: 'https://ucarecdn.com/d69daca4-550d-485c-b297-d93323a5bdbe/'
+readme: >
+  # Angular2 Material Dashboard Pro
+
+
+  Material-design Dashboard
+
+
+  ## How to run it
+
+
+  **- please ensure you have installed angular cli, otherwise `npm install -g
+  @angular/cli`**
+
+
+  1. git clone https://github.com/wangdicoder/angular-material-dashboard
+
+  2. cd angular-material-dashboard
+
+  3. npm install
+
+  4. ng serve -o (it will automatically open localhost:4200)
+
+
+  ## Further Plan
+
+  - [ ] Add Wizard Component
+
+  - [ ] Responsive Sidebar
+
+  - [ ] Consolidate form elements, like switch
+
+
+  ## Screenshot
+
+
+  ### Dashboard
+
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/dashboard.png)
+
+
+  ### Login
+
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/login.png)
+
+
+  ### Register
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/register.png)
+
+
+  ### Lock
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/lock.png)
+
+
+  ### User Profile
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/profile.png)
+
+
+  ### Sweet Alert
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/sweetalert.gif)
+
+
+  ### Notification
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/notification.gif)
+
+
+  ### Settings
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/settings.gif)
+
+
+  ### Table
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/table.png)
+
+
+  ### Price
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/price.png)
+
+
+  ### Panels
+
+  ![](https://github.com/wangdicoder/angular2-material-dashboard-pro/raw/master/screenshot/panel.png)
+
+
+  ## Acknowledge 
+
+
+  - [Creative Tim](https://github.com/creativetimofficial)
+
+  - [Sweet Alert 2](https://github.com/limonte/sweetalert2)
+
+  - [Bootstrap Notify](http://bootstrap-notify.remabledesigns.com)
+
+
+  ## License
+
+
+  MIT
+deployedAt: 2017-07-14T05:42:30.495Z


### PR DESCRIPTION

- Name: `angular-material-dashboard`
- Url: `git://github.com/wangdicoder/angular-material-dashboard.git`
- Cover Picture:
![](https://ucarecdn.com/d69daca4-550d-485c-b297-d93323a5bdbe/)
        