### PR TITLE
Add create-react-app-antd-typescript-starter to the market

### DIFF
--- a/scaffolds/create-react-app-antd-typescript-starter/index.yml
+++ b/scaffolds/create-react-app-antd-typescript-starter/index.yml
@@ -1,0 +1,13 @@
+name: create-react-app-antd-typescript-starter
+git_url: 'git://github.com/xlsdg/create-react-app-antd-typescript-starter.git'
+author: xlsdg
+description: Get started with create-react-app and antd.
+tags:
+  - 'create-react-app '
+  - antd
+  - typescript
+coverPicture: null
+readme: |
+  # create-react-app-antd-typescript-starter
+  Get started with create-react-app and antd.
+deployedAt: 2018-01-09T02:41:09.583Z


### PR DESCRIPTION

- Name: `create-react-app-antd-typescript-starter`
- Url: `git://github.com/xlsdg/create-react-app-antd-typescript-starter.git`

        