### PR TITLE
Add material-demo to the market

### DIFF
--- a/scaffolds/material-demo/index.yml
+++ b/scaffolds/material-demo/index.yml
@@ -1,0 +1,7 @@
+name: material-demo
+git_url: 'git://github.com/toolaugh/material-demo.git'
+author: toolaugh
+description: using material-design
+tags: []
+coverPicture: null
+deployedAt: 2018-07-03T10:55:36.539Z


### PR DESCRIPTION

- Name: `material-demo`
- Url: `git://github.com/toolaugh/material-demo.git`

        