### PR TITLE
Add ant-design-pro-vue to the market

### DIFF
--- a/scaffolds/ant-design-pro-vue/index.yml
+++ b/scaffolds/ant-design-pro-vue/index.yml
@@ -1,0 +1,10 @@
+name: ant-design-pro-vue
+git_url: 'git://github.com/sendya/ant-design-pro-vue.git'
+author: sendya
+description: "\U0001F468\U0001F3FB‍\U0001F4BB\U0001F469\U0001F3FB‍\U0001F4BB Use Ant Design Vue like a Pro! Demo: https://pro.loacg.com"
+tags:
+  - vue
+  - antd
+  - antd-pro
+coverPicture: 'https://ucarecdn.com/3538f9ed-1b3a-4817-9f5e-2f880568fd37/'
+deployedAt: 2018-11-30T09:35:13.642Z


### PR DESCRIPTION

- Name: `ant-design-pro-vue`
- Url: `git://github.com/sendya/ant-design-pro-vue.git`
- Cover Picture:
![](https://ucarecdn.com/3538f9ed-1b3a-4817-9f5e-2f880568fd37/)
        