### PR TITLE
Add electron-react-typescript-antd-boilerplate to the market

### DIFF
--- a/scaffolds/electron-react-typescript-antd-boilerplate/index.yml
+++ b/scaffolds/electron-react-typescript-antd-boilerplate/index.yml
@@ -1,0 +1,7 @@
+name: electron-react-typescript-antd-boilerplate
+git_url: 'git://github.com/CNLHC/electron-react-typescript-antd-boilerplate.git'
+author: CNLHC
+description: Electron+Typescript脚手架
+tags: []
+coverPicture: 'https://ucarecdn.com/2999e79c-73ae-4873-9db5-c0a856bc413d/'
+deployedAt: 2019-01-29T13:03:28.560Z


### PR DESCRIPTION

- Name: `electron-react-typescript-antd-boilerplate`
- Url: `git://github.com/CNLHC/electron-react-typescript-antd-boilerplate.git`
- Cover Picture:
![](https://ucarecdn.com/2999e79c-73ae-4873-9db5-c0a856bc413d/)
        