### PR TITLE
remove d2-admin

### DIFF
--- a/scaffolds/d2-admin/index.yml
+++ b/scaffolds/d2-admin/index.yml
@@ -1,8 +1,0 @@
-name: d2-admin
-git_url: 'git://github.com/d2-projects/d2-admin.git'
-author: d2-projects
-description: An elegant dashboard
-tags:
-  - vue
-coverPicture: 'https://qiniucdn.fairyever.com/20190226161826.png'
-deployedAt: 2018-07-30T05:42:48.123Z


### PR DESCRIPTION
因为 https://github.com/ant-design/scaffold-market/issues/243
需要删除相关资料后重新申请收录