### PR TITLE
Fix to Issue # 267

### DIFF
--- a/src/services/list.js
+++ b/src/services/list.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export function fetch() {
-  return axios.get('http://scaffold.ant.design/list.json');
+  return axios.get('https://scaffold.ant.design/list.json');
 }
 
 export function fetchReadme(user, repo) {


### PR DESCRIPTION
Changed list.json to be read from https rather than http. See[ issue # 267 ](https://github.com/ant-design/scaffold-market/issues/267)