### PR TITLE
Add umi-electron to the market

### DIFF
--- a/scaffolds/umi-electron/index.yml
+++ b/scaffolds/umi-electron/index.yml
@@ -1,0 +1,7 @@
+coverPicture: null
+name: umi-electron
+git_url: 'git://github.com/TtTRz/umi-electron.git'
+author: TtTRz
+description: UmiJS electron
+tags: []
+deployedAt: 2019-12-11T04:31:11.026Z


### PR DESCRIPTION

- Name: `umi-electron`
- Url: `git://github.com/TtTRz/umi-electron.git`

        