### PR TITLE
Add react-antd-dashboard to the market

### DIFF
--- a/scaffolds/react-antd-dashboard/index.yml
+++ b/scaffolds/react-antd-dashboard/index.yml
@@ -1,0 +1,7 @@
+coverPicture: null
+name: react-antd-dashboard
+git_url: 'git://github.com/theeranan/react-antd-dashboard.git'
+author: theeranan
+description: null
+tags: []
+deployedAt: 2020-10-27T07:58:18.157Z


### PR DESCRIPTION

- Name: `react-antd-dashboard`
- Url: `git://github.com/theeranan/react-antd-dashboard.git`

        