### PR TITLE
Add ant-design-pro-plus to the market

### DIFF
--- a/scaffolds/ant-design-pro-plus/index.yml
+++ b/scaffolds/ant-design-pro-plus/index.yml
@@ -1,0 +1,9 @@
+coverPicture: 'https://ucarecdn.com/8a1d4569-57a8-4c16-b58e-041931433c62/'
+name: ant-design-pro-plus
+git_url: 'git://github.com/theprimone/ant-design-pro-plus.git'
+author: theprimone
+description: ✨ 基于 ant-design-pro 做一些微小的工作。
+tags:
+  - ant-design-pro
+  - tabs
+deployedAt: 2021-06-30T06:33:07.275Z


### PR DESCRIPTION
- Name: `ant-design-pro-plus`
- Url: `git://github.com/theprimone/ant-design-pro-plus.git`
- Cover Picture:
![](https://repository-images.githubusercontent.com/195324784/177b7500-8a6c-11eb-9e06-b558882908d9)
        